### PR TITLE
Fixed the connection timeout issues when connecting to remote Cassand…

### DIFF
--- a/src/cassandra-client/index.ts
+++ b/src/cassandra-client/index.ts
@@ -50,6 +50,10 @@ export class CassandraClient extends EventEmitter {
 
         const options: cassandra.ClientOptions = {
             contactPoints: config.contactPoints,
+            socketOptions: {
+                connectTimeout: 60000,
+                readTimeout: 60000,
+            },
             // protocolOptions: {
             //     port: config.port,
             // },


### PR DESCRIPTION
Fixed the connection timeout issues when connecting to remote Cassandra databases that took more than 12 seconds to connect or readTimeout. The 12 seconds is the default value from the Cassandra-Driver of nodejs.

This is the fix for issue #4 which was not able to reproduce.